### PR TITLE
Fix README include for Pages build

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -3,4 +3,4 @@ layout: default
 title: "Bruno Fontana - CV"
 ---
 
-{% include README.md %}
+{% include_relative ../README.md %}


### PR DESCRIPTION
## Summary
- Adjust index to include the top-level README correctly using `include_relative`

## Testing
- `jekyll build --config site/_config.yml -s . -d _site` *(fails: command not found)*
- `gem install jekyll -v 3.10.0` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68976a2dfadc83229b707da5b7b5822b